### PR TITLE
Swap row and column starts when setting landscape mode

### DIFF
--- a/main.c
+++ b/main.c
@@ -14,6 +14,26 @@ int main(void) {
     st7735_init();
 
     st7735_set_orientation(ST7735_LANDSCAPE);
+    st7735_fill_rect(0, 0, 160, 128, ST7735_COLOR_RED);
+
+    _delay_ms(1000);
+
+    st7735_set_orientation(ST7735_PORTRAIT);
+    st7735_fill_rect(0, 0, 128, 160, ST7735_COLOR_BLUE);
+
+    _delay_ms(1000);
+
+    st7735_set_orientation(ST7735_LANDSCAPE_INV);
+    st7735_fill_rect(0, 0, 160, 128, ST7735_COLOR_YELLOW);
+
+    _delay_ms(1000);
+
+    st7735_set_orientation(ST7735_PORTRAIT_INV);
+    st7735_fill_rect(0, 0, 128, 160, ST7735_COLOR_GREEN);
+
+    _delay_ms(1000);
+
+    st7735_set_orientation(ST7735_LANDSCAPE);
     st7735_fill_rect(0, 0, 160, 128, ST7735_COLOR_BLACK);
 
     st7735_draw_mono_bitmap(16, 4, (PGM_P) logo_bw, ST7735_COLOR_WHITE, ST7735_COLOR_BLACK);

--- a/st7735.c
+++ b/st7735.c
@@ -6,6 +6,8 @@
 #include "spi.h"
 #include "st7735initcmds.h"
 
+uint8_t st7735_screen_row_start = 0;
+uint8_t st7735_screen_column_start = 0;
 uint8_t st7735_row_start = 0;
 uint8_t st7735_column_start = 0;
 uint8_t st7735_width = 0;
@@ -106,8 +108,8 @@ void st7735_init() {
 			st7735_run_command_list(st7735_red_init1);
 			st7735_run_command_list(st7735_red_init_green2);
 			st7735_run_command_list(st7735_red_init3);
-			st7735_column_start = 2;
-			st7735_row_start = 1;
+			st7735_column_start = st7735_screen_column_start = 2;
+			st7735_row_start = st7735_screen_row_start = 1;
 			st7735_width = st7735_default_width;
 			st7735_height = st7735_default_height_18;
 			break;
@@ -133,8 +135,8 @@ void st7735_init() {
 
 		case ST7735_RED144_GREENTAB:
 			st7735_height = st7735_default_height_144;
-			st7735_column_start = 2;
-			st7735_row_start = 3;
+			st7735_column_start = st7735_screen_column_start = 2;
+			st7735_row_start = st7735_screen_row_start = 3;
 			st7735_run_command_list(st7735_red_init1);
 			st7735_run_command_list(st7735_red_init_green1442);
 			st7735_run_command_list(st7735_red_init3);
@@ -143,8 +145,8 @@ void st7735_init() {
 			break;
 		case ST7735_RED144_JAYCAR:
 			st7735_height = st7735_default_height_144;
-			st7735_column_start = 32;
-			st7735_row_start = 0;
+			st7735_column_start = st7735_screen_column_start = 0;
+			st7735_row_start = st7735_screen_row_start = 32;
 			st7735_run_command_list(st7735_red_init1);
 			st7735_run_command_list(st7735_red_init_green1442);
 			st7735_run_command_list(st7735_red_init3);
@@ -187,10 +189,8 @@ void st7735_set_orientation(enum ST7735_ORIENTATION orientation) {
 			st7735_height = st7735_default_height_18;
 		    }
 
-		    if(st7735_type == ST7735_RED144_JAYCAR) {
-			st7735_column_start = 0;
-			st7735_row_start = 32;
-		    }
+			st7735_column_start = st7735_screen_column_start;
+			st7735_row_start = st7735_screen_row_start;
 			break;
 
 
@@ -216,6 +216,8 @@ void st7735_set_orientation(enum ST7735_ORIENTATION orientation) {
 			}
 
 			st7735_height = st7735_default_width;
+			st7735_column_start = st7735_screen_row_start;
+			st7735_row_start = st7735_screen_column_start;
 			break;
 
 		case ST7735_PORTRAIT_INV:
@@ -239,6 +241,8 @@ void st7735_set_orientation(enum ST7735_ORIENTATION orientation) {
 			if(st7735_type == ST7735_RED144_JAYCAR) {
 				st7735_column_start = 0;
 			}
+			st7735_column_start = st7735_screen_column_start;
+			st7735_row_start = st7735_screen_row_start;
 
 			break;
 
@@ -263,6 +267,8 @@ void st7735_set_orientation(enum ST7735_ORIENTATION orientation) {
 			}
 
 			st7735_height = st7735_default_width;
+			st7735_column_start = st7735_screen_row_start;
+			st7735_row_start = st7735_screen_column_start;
 			break;
 	}
 }


### PR DESCRIPTION
When setting landscape mode the row and column offset values need to be swapped because they are treated as related to the current mode. Requires swap back for portrait mode. This is treated the same in the Adafruit code.

Also updated main.c to quickly preview all orientations on startup. 

Since for all others the row and column defaults are for portrait mode I have removed the condition in  st7735_set_orientation for ST7735_RED144_JAYCAR  and reversed its defaults in st7735_init. But can't test it.